### PR TITLE
Revert "Bump openmrs-sdk-maven-plugin from 3.12.4 to 3.13.6"

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -33,7 +33,7 @@
 			<plugin>
 				<groupId>org.openmrs.maven.plugins</groupId>
 				<artifactId>openmrs-sdk-maven-plugin</artifactId>
-				<version>3.13.6</version>
+				<version>3.12.4</version>
 				<executions>
 					<execution>
 						<id>build-distro</id>


### PR DESCRIPTION
Reverts digitalhealthcaresociety/openmrs-distro-referenceapplication#7